### PR TITLE
Feature#27 전적 조회 기능에  소환사 정보만 추출하여 DB 저장

### DIFF
--- a/Search-service/src/main/java/com/ggwp/searchservice/match/controller/MatchController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/controller/MatchController.java
@@ -2,6 +2,7 @@ package com.ggwp.searchservice.match.controller;
 
 import com.ggwp.searchservice.match.service.MatchService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,7 +25,7 @@ public class MatchController {
     @GetMapping("get/match/{matchId}") // 매치 1개 api 불러와서 저장
     public ResponseEntity<?> getMatch(@PathVariable String matchId){
         System.out.println("matchId = " + matchId);
-
-        return ResponseEntity.ok(matchService.getMatch(matchId));
+        matchService.createMatch(matchId);
+        return ResponseEntity.ok(HttpStatus.CREATED);
     }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Participant.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Participant.java
@@ -1,6 +1,8 @@
 package com.ggwp.searchservice.match.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ggwp.searchservice.summoner.domain.Summoner;
+import com.ggwp.searchservice.summoner.dto.RequestCreateSummonerDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,6 +36,7 @@ public class Participant {
 
     @Column(name = "summoner_level")
     private Long summonerLevel;
+
     ////////////////////////////////////////////////////////////
 
     private int champExperience; // 챔피언 숙련도
@@ -74,4 +77,13 @@ public class Participant {
     @JoinColumn(name = "team_id")
     private Team team;
 
+    public RequestCreateSummonerDto createSummoner(){
+        return RequestCreateSummonerDto.builder()
+                .id(this.summonerId)
+                .profileIconId(this.profileIcon)
+                .puuid(this.puuid)
+                .name(this.summonerName)
+                .summonerLevel(this.summonerLevel)
+                .build();
+    }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchDto.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ggwp.searchservice.match.domain.Match;
 import com.ggwp.searchservice.match.domain.Participant;
 import com.ggwp.searchservice.match.domain.Team;
+import com.ggwp.searchservice.summoner.domain.Summoner;
+import com.ggwp.searchservice.summoner.service.SummonerService;
 import lombok.*;
 
 import java.util.List;
@@ -11,9 +13,9 @@ import java.util.stream.Collectors;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@RequiredArgsConstructor
 public class MatchDto {
 
     @JsonProperty("info")
@@ -21,6 +23,8 @@ public class MatchDto {
 
     @JsonProperty("metadata")
     private MetadataDto metadataDto;
+
+    List<Participant> participantEntities;
 
     @Getter
     @Setter
@@ -52,7 +56,7 @@ public class MatchDto {
                 })
                 .collect(Collectors.toList());
 
-        List<Participant> participantEntities = info.getParticipants().stream()
+        participantEntities = info.getParticipants().stream()
                 .map(participantDto -> {
                     int teamId = participantDto.getTeamId();
 
@@ -70,6 +74,7 @@ public class MatchDto {
         match.setTeams(teamEntities);
         return match;
     }
+
 
 
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/dto/ParticipantDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/dto/ParticipantDto.java
@@ -3,6 +3,7 @@ package com.ggwp.searchservice.match.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ggwp.searchservice.match.domain.Participant;
 import com.ggwp.searchservice.match.domain.Team;
+import com.ggwp.searchservice.summoner.dto.RequestCreateSummonerDto;
 import lombok.*;
 
 @Getter
@@ -92,7 +93,6 @@ public class ParticipantDto {
 
     @JsonProperty("teamPosition")
     private String teamPosition;
-
     public Participant toEntity(Team team) {
         return Participant.builder()
                 .participantId(this.participantId)

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
@@ -2,11 +2,16 @@ package com.ggwp.searchservice.match.service;
 
 import com.ggwp.searchservice.match.MatchRepository.MatchRepository;
 import com.ggwp.searchservice.match.domain.Match;
+import com.ggwp.searchservice.match.domain.Participant;
 import com.ggwp.searchservice.match.dto.MatchDto;
 import com.ggwp.searchservice.match.feign.LoLToMatchFeign;
+import com.ggwp.searchservice.summoner.dto.RequestCreateSummonerDto;
+import com.ggwp.searchservice.summoner.service.SummonerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,12 +23,20 @@ public class MatchService {
     private final LoLToMatchFeign matchFeign;
 
     private final MatchRepository matchRepository;
-    public MatchDto getMatch(String matchId) {
 
-           MatchDto matchDto = matchFeign.getMatch(matchId, apiKey);
-           Match match = matchDto.toEntity();
-           matchRepository.save(match);
-            return matchDto;
+    private final SummonerService summonerService;
+
+    public void createMatch(String matchId) {
+        MatchDto matchDto = matchFeign.getMatch(matchId, apiKey);
+        Match match = matchDto.toEntity();
+        matchRepository.save(match);
+
+        List<Participant> participants = matchDto.getParticipantEntities();
+
+        for (Participant participant : participants) {
+            RequestCreateSummonerDto summonerDto = participant.createSummoner();
+            summonerService.createSummoner(summonerDto);
+        }
     }
 
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/domain/Summoner.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/domain/Summoner.java
@@ -25,7 +25,7 @@ public class Summoner {
     @Column(name = "summoner_id")
     private String id; // summoner_id encrypted
 
-    private Long profileIconId; // 프로필 아이콘 번호
+    private int profileIconId; // 프로필 아이콘 번호
 
 //    private String accountId; // account encrypted 필요없어 보임
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/dto/RequestCreateSummonerDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/dto/RequestCreateSummonerDto.java
@@ -12,11 +12,10 @@ import java.time.ZoneOffset;
 @NoArgsConstructor
 @Builder
 public class RequestCreateSummonerDto {
+
     private String id;
 
-    private Long profileIconId;
-
-//    private String accountId;
+    private int profileIconId;
 
     private String puuid;
 
@@ -25,6 +24,8 @@ public class RequestCreateSummonerDto {
     private Long revisionDate;
 
     private Long summonerLevel;
+
+    //    private String accountId;
 
     // DTO를 -> Entity 로 변경
     public Summoner toEntity() {

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/dto/ResponseGetSummonerDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/dto/ResponseGetSummonerDto.java
@@ -16,7 +16,7 @@ public class ResponseGetSummonerDto {
 
     private String id;
 
-    private Long profileIconId;
+    private int profileIconId;
 
 //    private String accountId;
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/repository/SummonerRepository.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/repository/SummonerRepository.java
@@ -10,4 +10,6 @@ public interface SummonerRepository extends JpaRepository<Summoner,Long> {
     Summoner findSummonerByName(String name);
 
     Summoner findSummonerById(String id);
+
+    boolean existsById(String id);
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerService.java
@@ -9,6 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class SummonerService {
@@ -36,7 +39,24 @@ public class SummonerService {
 
     // match 값에서 가져온 정보로 summoner 저장
     public void createSummoner(RequestCreateSummonerDto summonerDto){
-        Summoner summoner = summonerDto.toEntity();
-        summonerRepository.save(summoner);
+        if (!summonerRepository.existsById(summonerDto.getId())) {
+            Summoner summoner = summonerDto.toEntity();
+            summonerRepository.save(summoner);
+        }
     }
+
+
+//    public void createSummoners(List<RequestCreateSummonerDto> summonerDtos) {
+//        List<Summoner> summoners = new ArrayList<>();
+//
+//        for (RequestCreateSummonerDto summonerDto : summonerDtos) {
+//            // 검색
+//            if (!summonerRepository.existsById(summonerDto.getId())) {
+//                Summoner summoner = summonerDto.toEntity();
+//                summoners.add(summoner);
+//            }
+//        }
+//        summonerRepository.saveAll(summoners);
+//    }
+
 }

--- a/Search-service/src/main/resources/application.yml
+++ b/Search-service/src/main/resources/application.yml
@@ -15,7 +15,7 @@
     # jpa
     jpa:
       hibernate:
-        ddl-auto: update
+        ddl-auto: create
       properties:
         hibernate:
           format_sql: true


### PR DESCRIPTION
Feature#27 전적 조회 기능에  소환사 정보만 추출하여 DB 저장

기존 기능을 refactor 해서 commit 또한 refactor로 함

전적 기능을 호출할 시, 소환사 DB에 저장되는 것 확인했음

- 이후에 롤 API 호출해서 가져오는 것이 아닌 DB에 있는 match_id를 호출하여 가져오는 getmapping 추후 기능 구현 예정