### PR TITLE
Refactor: [백엔드] db에 저장된 전적 조회하기 기능 구현 feature#52

### DIFF
--- a/Search-service/src/main/java/com/ggwp/searchservice/match/MatchRepository/MatchRepository.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/MatchRepository/MatchRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
 
-    boolean existsByMatchId(String matchId);
+    Match findByMatchId(String matchId);
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/MatchRepository/MatchSummonerRepository.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/MatchRepository/MatchSummonerRepository.java
@@ -3,6 +3,10 @@ package com.ggwp.searchservice.match.MatchRepository;
 import com.ggwp.searchservice.match.domain.MatchSummoner;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MatchSummonerRepository extends JpaRepository<MatchSummoner, Long> {
+
+    List<MatchSummoner> findBySummonerId(String summonerId);
     
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/controller/MatchController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/controller/MatchController.java
@@ -4,8 +4,8 @@ import com.ggwp.searchservice.match.service.MatchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,11 +16,14 @@ public class MatchController {
 
     private final MatchService matchService;
 
-    @GetMapping("matchlist/{puuid}") // 매치 1개 api 불러와서 저장
-    public ResponseEntity<?> getMatch(@PathVariable String puuid) {
-
+    @PostMapping("matchlist/{puuid}/save") // 매치 5개 api 불러와서 저장
+    public ResponseEntity<?> createMatch(@PathVariable String puuid) {
         matchService.createMatch(puuid);
-
         return ResponseEntity.ok(HttpStatus.CREATED);
+    }
+
+    @PostMapping("/matchlist/{summonerId}/get")
+    public ResponseEntity<?> getMatchList(@PathVariable String summonerId) {
+        return ResponseEntity.ok(matchService.getMatchList(summonerId));
     }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Match.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Match.java
@@ -1,11 +1,11 @@
 package com.ggwp.searchservice.match.domain;
 
-import com.ggwp.searchservice.summoner.domain.Summoner;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,15 +39,11 @@ public class Match {
     @Column(name = "game_start_timestamp")
     private long gameStartTimestamp; // 게임 시작 시각
 
-    @OneToMany(mappedBy = "match", cascade = CascadeType.ALL)
-    private List<Team> teams = new ArrayList<>(); // 매치 1 팀 2
+    @OneToMany(mappedBy = "match", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Team> teams = new ArrayList<>();
 
-    @ManyToMany
-    @JoinTable(
-            name = "match_summoner",
-            joinColumns = @JoinColumn(name = "match_id"),
-            inverseJoinColumns = @JoinColumn(name = "summoner_id"))
-    private List<Summoner> summoners = new ArrayList<>();
+    @OneToMany(mappedBy = "match", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<MatchSummoner> matchSummoners = new ArrayList<>();
 
     public void addTeams(List<Team> teams) {
         this.teams.addAll(teams);
@@ -56,12 +52,13 @@ public class Match {
         }
     }
 
-    public void addSummoners(List<Summoner> summonerList) {
-        if (this.summoners == null) {
-            this.summoners = new ArrayList<>();
+    public void addMatchSummoners(List<MatchSummoner> matchSummoners) {
+        Hibernate.initialize(this.matchSummoners);
+
+        if (this.matchSummoners == null) {
+            this.matchSummoners = new ArrayList<>();
         }
-        // 명시적으로 로딩
-        this.summoners.size(); // 또는 다른 메서드 호출을 통한 로딩
-        this.summoners.addAll(summonerList);
+
+        this.matchSummoners.addAll(matchSummoners);
     }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/MatchSummoner.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/MatchSummoner.java
@@ -1,29 +1,28 @@
 package com.ggwp.searchservice.match.domain;
 
 import com.ggwp.searchservice.summoner.domain.Summoner;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-
+import lombok.NoArgsConstructor;
 
 @Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Getter
 public class MatchSummoner {
 
     @Id
-    private String matchId;
-
-    @Id
-    private String summonerId;
+    @GeneratedValue
+    private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "match_id", insertable = false, updatable = false)
+    @JoinColumn(name = "match_id")
     private Match match;
 
     @ManyToOne
-    @JoinColumn(name = "summoner_id", insertable = false, updatable = false)
+    @JoinColumn(name = "summoner_id")
     private Summoner summoner;
-
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Participant.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Participant.java
@@ -15,6 +15,10 @@ import lombok.NoArgsConstructor;
 public class Participant {
 
     @Id
+    @GeneratedValue
+    @Column(name = "participant_pk")
+    private Long participantPk;
+
     @Column(name = "participant_id")
     private int participantId; // participant의 PK
 
@@ -69,14 +73,10 @@ public class Participant {
     @Column(name = "sub_style")
     private int subStyle;
 
-    @ManyToOne
-    @JoinColumn(name = "team_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_pk")
     private Team team;
 
-    @ManyToOne(cascade = CascadeType.ALL)  // 이 부분 추가
-    @JoinColumn(name = "match_id")
-    private Match match;
-    
     public RequestCreateSummonerDto createSummoner() {
         return RequestCreateSummonerDto.builder()
                 .id(this.summonerId)

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Team.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Team.java
@@ -1,8 +1,10 @@
 package com.ggwp.searchservice.match.domain;
 
-import com.ggwp.searchservice.enums.TeamColors;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,13 +17,17 @@ import java.util.List;
 public class Team {
 
     @Id
+    @GeneratedValue
+    @Column(name = "team_pk")
+    private Long teamPk;
+
     private int teamId; // teamId 100 = BLUE 200 = RED
 
     private boolean win; // 승리
 
     @ManyToOne
     @JoinColumn(name = "match_id")
-    private Match match; // match랑 연관관계
+    private Match match; // match와 연관관계
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
     private List<Participant> participants = new ArrayList<>(); // 참가자들 5명 씩 팀 1, 팀 2

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchSummonerDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchSummonerDto.java
@@ -1,0 +1,24 @@
+package com.ggwp.searchservice.match.dto;
+
+import com.ggwp.searchservice.match.domain.MatchSummoner;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MatchSummonerDto {
+    private String matchId;
+    private String summonerId;
+    // 기타 필요한 필드 추가
+
+    public static MatchSummonerDto toDto(MatchSummoner matchSummoner) {
+        return MatchSummonerDto.builder()
+                .matchId(matchSummoner.getMatch().getMatchId())
+                .summonerId(matchSummoner.getSummoner().getId())
+                // 기타 필요한 필드 설정
+                .build();
+    }
+}
+

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
@@ -3,64 +3,97 @@ package com.ggwp.searchservice.match.service;
 import com.ggwp.searchservice.match.MatchRepository.MatchRepository;
 import com.ggwp.searchservice.match.MatchRepository.MatchSummonerRepository;
 import com.ggwp.searchservice.match.domain.Match;
-import com.ggwp.searchservice.match.domain.Participant;
+import com.ggwp.searchservice.match.domain.MatchSummoner;
 import com.ggwp.searchservice.match.dto.MatchDto;
+import com.ggwp.searchservice.match.dto.MatchSummonerDto;
 import com.ggwp.searchservice.match.feign.LoLToMatchFeign;
 import com.ggwp.searchservice.summoner.domain.Summoner;
 import com.ggwp.searchservice.summoner.dto.RequestCreateSummonerDto;
 import com.ggwp.searchservice.summoner.repository.SummonerRepository;
-import com.ggwp.searchservice.summoner.service.SummonerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MatchService {
 
     private final LoLToMatchFeign matchFeign;
     private final MatchRepository matchRepository;
     private final SummonerRepository summonerRepository;
-    private final SummonerService summonerService;
     private final MatchSummonerRepository matchSummonerRepository;
-    
+
     @Value("${LOL.apikey}")
     private String apiKey;
 
     public void createMatch(String puuid) {
+        List<String> matchIds = matchFeign.getMatchIds(puuid, apiKey); // matchIds 5개 가져오기
 
-        List<String> matchIds = matchFeign.getMatchIds(puuid, apiKey);
+        for (String matchId : matchIds) { // 5번 반복한다.
+            MatchDto matchDto = matchFeign.getMatch(matchId, apiKey); // matchId로 전적 조회
 
-        for (String matchId : matchIds) {
+            Match match = matchDto.toEntity(); // 엔티티로 변환
+            matchRepository.save(match); // match 저장
+            // match는 summoner가 여러개를 가질 수 있다. @ManyToMany
+            // summoner는 match를 여러개 가질 수 있다. @ManyToMany
+            // @ManyToMany를 사용하지 않고 OneToMany(Match) - ManyToOne(MatchSummoner) - OneToMany(Summoner) 로 매핑하기로 함
+            // match에다가 MatchSummoner를 저장해야함 -> 저장하기 위해선, 우선 summoner부터 먼저 저장해야함
+            // Summoner에다가도 MatchSummoner를 저장해야함
+            List<MatchDto.ParticipantDto> participantDtoList = matchDto.getInfo().getParticipants();
 
-            MatchDto matchDto = matchFeign.getMatch(matchId, apiKey);
-            Match match = matchDto.toEntity();
-
-            List<Summoner> summoners = new ArrayList<>();
-
-            List<Participant> participants = matchDto.getParticipantEntities();
-
-            for (Participant participant : participants) {
-                Summoner summoner = summonerRepository.findSummonerById(participant.getSummonerId());
-                if (summoner == null) {
-                    RequestCreateSummonerDto summonerDto = participant.createSummoner();
-                    summoner = summonerService.createSummoner(summonerDto);
-                }
-                summoners.add(summoner);
+            List<MatchSummoner> matchSummonerList = new ArrayList<>(); // matchSummoner를 한 번에 저장해줄 리스트 선언, db에 저장을 한 번에 하기 위함
+            for (MatchDto.ParticipantDto participantDto : participantDtoList) {
+                RequestCreateSummonerDto createSummonerDto = participantDto.createSummonerDto();
+                Summoner summoner = createSummonerDto.toEntity();
+                // summoner를 저장 하기 전 MatchSummoner를 만들어 summoner에 넣어줘야 한다.
+                MatchSummoner matchSummoner = MatchSummoner.builder()
+                        .summoner(summoner)
+                        .match(match)
+                        .build();
+                summoner.addMatchSummoner(matchSummoner); // summoner에다가 matchsummoner 넣어주기
+                summonerRepository.save(summoner); // summoner 저장
+                matchSummonerList.add(matchSummoner); // matchSummoner List에다가 저장
             }
-            match.addSummoners(summoners);
+            // match에 들어갈 matchSummoner
+            match.addMatchSummoners(matchSummonerList);
 
-            matchRepository.save(match);
-
-            for (Summoner summoner : summoners) {
-                summoner.addMatch(match);
-                summonerRepository.save(summoner);
-            }
-
+            matchSummonerRepository.saveAll(matchSummonerList); // matchSummoner List 저장
         }
+    }
 
+
+    // 소환사의 matchId들 matchSummoner에서 가져오기
+    @Transactional(readOnly = true)
+    public List<MatchSummonerDto> getMatchSummonerBySummonerId(String summonerId) {
+        List<MatchSummoner> matchSummoners = matchSummonerRepository.findBySummonerId(summonerId);
+
+        List<MatchSummonerDto> matchSummonerDtoList = new ArrayList<>();
+
+        for (MatchSummoner matchSummoner : matchSummoners) {
+            MatchSummonerDto matchSummonerDto = MatchSummonerDto.toDto(matchSummoner);
+            matchSummonerDtoList.add(matchSummonerDto);
+        }
+        return matchSummonerDtoList;
+    }
+
+    // 가져온 matchId로 전적 db에서 조회해서 가져오기
+    @Transactional(readOnly = true)
+    public List<MatchDto> getMatchList(String summonerId) {
+        List<MatchSummonerDto> matchSummonerDtoList = getMatchSummonerBySummonerId(summonerId);
+
+        List<MatchDto> matchDtoList = new ArrayList<>();
+        for (MatchSummonerDto matchSummonerDto : matchSummonerDtoList) {
+            Match match = matchRepository.findByMatchId(matchSummonerDto.getMatchId());
+            MatchDto matchDto = MatchDto.toDto(match);
+            matchDtoList.add(matchDto);
+        }
+        return matchDtoList;
     }
 }
+
+

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/domain/Summoner.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/domain/Summoner.java
@@ -1,13 +1,14 @@
 package com.ggwp.searchservice.summoner.domain;
 
 import com.ggwp.searchservice.league.domain.League;
-import com.ggwp.searchservice.match.domain.Match;
+import com.ggwp.searchservice.match.domain.MatchSummoner;
 import com.ggwp.searchservice.summoner.dto.ResponseGetSummonerDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,8 +40,8 @@ public class Summoner {
     @OneToMany(mappedBy = "summoner")
     private List<League> leagues;
 
-    @ManyToMany(mappedBy = "summoners")
-    private List<Match> matches = new ArrayList<>();
+    @OneToMany(mappedBy = "summoner", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<MatchSummoner> matchSummoners = new ArrayList<>();
 
     // 소환사 Entity를 -> DTO로 변경
     public ResponseGetSummonerDto toDto(Summoner summoner) {
@@ -55,11 +56,18 @@ public class Summoner {
                 .build();
     }
 
-    public void addMatch(Match match) {
-        if (this.matches == null) {
-            this.matches = new ArrayList<>();
+    public void addMatchSummoner(MatchSummoner matchSummoner) {
+        // Hibernate.initialize를 통해 matchSummoners 필드 초기화
+        Hibernate.initialize(this.matchSummoners);
+
+        // this.matchSummoners가 null이면 새로운 ArrayList를 생성하여 할당
+        if (this.matchSummoners == null) {
+            this.matchSummoners = new ArrayList<>();
         }
-        this.matches.size(); // Lazy 때문에 해야함
-        this.matches.add(match);
+
+        // this.matchSummoners에 새로운 MatchSummoner 추가
+        this.matchSummoners.add(matchSummoner);
+
+        // 이미 값이 담겨있다고 가정하고, 따로 연관관계 설정이 필요하지 않음
     }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/repository/SummonerRepository.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/repository/SummonerRepository.java
@@ -4,7 +4,7 @@ package com.ggwp.searchservice.summoner.repository;
 import com.ggwp.searchservice.summoner.domain.Summoner;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SummonerRepository extends JpaRepository<Summoner,Long> {
+public interface SummonerRepository extends JpaRepository<Summoner, Long> {
 
     // 닉네임으로 Summoner 찾기
     Summoner findSummonerByName(String name);
@@ -12,4 +12,6 @@ public interface SummonerRepository extends JpaRepository<Summoner,Long> {
     Summoner findSummonerById(String id);
 
     boolean existsById(String id);
+
+    Summoner findSummonerByPuuid(String puuid);
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerService.java
@@ -1,7 +1,6 @@
 package com.ggwp.searchservice.summoner.service;
 
 import com.ggwp.searchservice.summoner.domain.Summoner;
-import com.ggwp.searchservice.summoner.dto.RequestCreateSummonerDto;
 import com.ggwp.searchservice.summoner.dto.ResponseGetSummonerDto;
 import com.ggwp.searchservice.summoner.feign.LOLToSummonerFeign;
 import com.ggwp.searchservice.summoner.repository.SummonerRepository;
@@ -31,30 +30,5 @@ public class SummonerService {
         ResponseGetSummonerDto summonerDto = summoner.toDto(summoner);
         return summonerDto;
     }
-
-    // match 값에서 가져온 정보로 summoner 저장
-    public Summoner createSummoner(RequestCreateSummonerDto summonerDto) {
-        if (!summonerRepository.existsById(summonerDto.getId())) {
-            Summoner summoner = summonerDto.toEntity();
-            summonerRepository.save(summoner);
-
-            return summoner;
-        }
-        return null;
-    }
-
-
-//    public void createSummoners(List<RequestCreateSummonerDto> summonerDtos) {
-//        List<Summoner> summoners = new ArrayList<>();
-//
-//        for (RequestCreateSummonerDto summonerDto : summonerDtos) {
-//            // 검색
-//            if (!summonerRepository.existsById(summonerDto.getId())) {
-//                Summoner summoner = summonerDto.toEntity();
-//                summoners.add(summoner);
-//            }
-//        }
-//        summonerRepository.saveAll(summoners);
-//    }
 
 }

--- a/Search-service/src/main/resources/application-dev.yml
+++ b/Search-service/src/main/resources/application-dev.yml
@@ -13,7 +13,7 @@ spring:
   # jpa
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
- 전적 저장하기
- 전적 조회하기

-연관관계를 위해 MatchSummoner 엔티티 생성
- 레포지토리 구성

team participant가 저장이 1개의 매치만 저장이 되는 것을 확인 -> PK를 추가형 team과 paritipant도 전체 저장

트랜잭션: 영속성 컨텍스트 활용하여 match 저장, 업데이트