### PR TITLE
[백엔드] 롤 네임태그 추가 feature#57

### DIFF
--- a/Search-service/src/main/java/com/ggwp/searchservice/account/controller/AccountController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/controller/AccountController.java
@@ -1,0 +1,29 @@
+package com.ggwp.searchservice.account.controller;
+
+import com.ggwp.searchservice.account.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("v1/account")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @PostMapping("/{lol_name}/{tagLine}")
+    public ResponseEntity<?> createAccount(@PathVariable String lol_name, @PathVariable String tagLine) { // 토큰에서 닉네임과 태그를 받는다. (토큰 받으면 수정)
+        accountService.createAccount(lol_name, tagLine);
+        return ResponseEntity.ok(HttpStatus.CREATED);
+    }
+
+    @PostMapping("/{lol_name}/{tagLine}/getAccount")
+    public ResponseEntity<?> getAccount(@PathVariable String lol_name, @PathVariable String tagLine) { // DB에서 조회
+        return ResponseEntity.ok(accountService.getAccount(lol_name, tagLine));
+    }
+}

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/domain/Account.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/domain/Account.java
@@ -1,0 +1,30 @@
+package com.ggwp.searchservice.account.domain;
+
+import com.ggwp.searchservice.summoner.domain.Summoner;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Account {
+
+    @Id
+    private String puuid;
+
+    private String gameName;
+
+    private String tagLine;
+
+    @OneToOne
+    @JoinColumn(name = "account")
+    private Summoner summoner;
+}

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/dto/AccountDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/dto/AccountDto.java
@@ -1,0 +1,30 @@
+package com.ggwp.searchservice.account.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ggwp.searchservice.account.domain.Account;
+import com.ggwp.searchservice.summoner.domain.Summoner;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccountDto {
+
+    @JsonProperty("puuid")
+    private String puuid;
+    @JsonProperty("gameName")
+    private String gameName;
+    @JsonProperty("tagLine")
+    private String tagLine;
+
+    public Account toEntity(Summoner summoner) {
+        return Account.builder()
+                .puuid(this.puuid)
+                .gameName(this.gameName)
+                .tagLine(this.tagLine)
+                .summoner(summoner)
+                .build();
+    }
+}

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/feign/LOLToAccountFeign.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/feign/LOLToAccountFeign.java
@@ -1,0 +1,20 @@
+package com.ggwp.searchservice.account.feign;
+
+import com.ggwp.searchservice.account.dto.AccountDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "lol-account", url = "https://asia.api.riotgames.com/riot/")
+public interface LOLToAccountFeign {
+
+
+    @GetMapping("account/v1/accounts/by-riot-id/{lol_name}/{tagLine}")
+    AccountDto getAccount(
+            @PathVariable String lol_name,
+            @PathVariable String tagLine,
+            @RequestParam("api_key") String apiKey
+    );
+
+}

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/repository/AccountRepository.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/repository/AccountRepository.java
@@ -1,0 +1,9 @@
+package com.ggwp.searchservice.account.repository;
+
+import com.ggwp.searchservice.account.domain.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    Account findByGameNameAndTagLine(String gameName, String tagLine);
+}

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/service/AccountService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/service/AccountService.java
@@ -21,7 +21,7 @@ public class AccountService {
     @Value("${LOL.apikey}")
     private String apiKey;
 
-    public void createAccount(String lol_name, String tagLine) {
+    public void createAccount(String lol_name, String tagLine) { // api 호출
         AccountDto accountDto = accountFeign.getAccount(lol_name, tagLine, apiKey);
 
         if (summonerRepository.existsByPuuid(accountDto.getPuuid())) {
@@ -33,7 +33,7 @@ public class AccountService {
 
     }
 
-    public AccountDto getAccount(String lol_name, String tagLine) {
+    public AccountDto getAccount(String lol_name, String tagLine) { // DB 검색
         Account account = accountRepository.findByGameNameAndTagLine(lol_name, tagLine);
 
         return AccountDto.builder()

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/service/AccountService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/service/AccountService.java
@@ -1,0 +1,45 @@
+package com.ggwp.searchservice.account.service;
+
+import com.ggwp.searchservice.account.domain.Account;
+import com.ggwp.searchservice.account.dto.AccountDto;
+import com.ggwp.searchservice.account.feign.LOLToAccountFeign;
+import com.ggwp.searchservice.account.repository.AccountRepository;
+import com.ggwp.searchservice.summoner.domain.Summoner;
+import com.ggwp.searchservice.summoner.repository.SummonerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+    private final LOLToAccountFeign accountFeign;
+    private final SummonerRepository summonerRepository;
+
+    @Value("${LOL.apikey}")
+    private String apiKey;
+
+    public void createAccount(String lol_name, String tagLine) {
+        AccountDto accountDto = accountFeign.getAccount(lol_name, tagLine, apiKey);
+
+        if (summonerRepository.existsByPuuid(accountDto.getPuuid())) {
+            Summoner summoner = summonerRepository.findSummonerByPuuid(accountDto.getPuuid());
+            accountRepository.save(accountDto.toEntity(summoner));
+        }
+
+        // summoner가 없다면 롤 api를 호출하여 summoner를 가져온다.
+
+    }
+
+    public AccountDto getAccount(String lol_name, String tagLine) {
+        Account account = accountRepository.findByGameNameAndTagLine(lol_name, tagLine);
+
+        return AccountDto.builder()
+                .puuid(account.getPuuid())
+                .gameName(account.getGameName())
+                .tagLine(account.getTagLine())
+                .build();
+    }
+}

--- a/Search-service/src/main/java/com/ggwp/searchservice/league/controller/LeagueController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/league/controller/LeagueController.java
@@ -21,16 +21,16 @@ public class LeagueController {
 
     private final LeagueService leagueService;
 
-    @GetMapping("get/{summonerid}") // summoner_id
+    @GetMapping("/get/{summonerid}") // summoner_id
     @Operation(summary = "League (랭크 조회)", description = "encrypted된 id로 랭크 조회")
-    public ResponseEntity<?> getLeagues(@PathVariable String summonerid){
-       List<ResponseGetLeagueDto> leagueDto = leagueService.getLeaguesAndSave(summonerid);
+    public ResponseEntity<?> getLeagues(@PathVariable String summonerid) {
+        List<ResponseGetLeagueDto> leagueDto = leagueService.getLeaguesAndSave(summonerid);
         return ResponseEntity.ok(leagueDto);
     }
 
-    @GetMapping("get/{summonerId}/no-api")
+    @GetMapping("/get/{summonerId}/no-api")
     @Operation(summary = "League (랭크 조회)", description = "DB로 조회")
-    public ResponseEntity<?> getLeaguesNoApi(@PathVariable String summonerId){
+    public ResponseEntity<?> getLeaguesNoApi(@PathVariable String summonerId) {
         List<ResponseFindLeagueDto> leagueDto = leagueService.getLeaguesNoApi(summonerId);
         return ResponseEntity.ok(leagueDto);
     }

--- a/Search-service/src/main/java/com/ggwp/searchservice/league/domain/League.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/league/domain/League.java
@@ -1,6 +1,5 @@
 package com.ggwp.searchservice.league.domain;
 
-import com.ggwp.searchservice.enums.GameMode;
 import com.ggwp.searchservice.summoner.domain.Summoner;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -16,6 +15,10 @@ import lombok.NoArgsConstructor;
 public class League {
 
     @Id
+    @GeneratedValue
+    @Column(name = "league_pk")
+    private Long id;
+
     private String leagueId; // 리그 아이디 encrypted
 
     private String queueType; // 게임 모드
@@ -31,7 +34,7 @@ public class League {
     private int losses; // 패배
 
     // 다대일 연결 ( 리그 2 : 소환사 1)
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "summoner_id")
     private Summoner summoner;
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/league/dto/ResponseFindLeagueDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/league/dto/ResponseFindLeagueDto.java
@@ -1,7 +1,7 @@
 package com.ggwp.searchservice.league.dto;
 
-import com.ggwp.searchservice.enums.GameMode;
 import com.ggwp.searchservice.league.domain.League;
+import com.ggwp.searchservice.summoner.domain.Summoner;
 import lombok.*;
 
 @Getter
@@ -25,7 +25,7 @@ public class ResponseFindLeagueDto {
 
     private int losses;
 
-    private String summonerId;
+    private Summoner summoner;
 
     public static ResponseFindLeagueDto toDto(League league) {
         return ResponseFindLeagueDto.builder()
@@ -36,7 +36,7 @@ public class ResponseFindLeagueDto {
                 .leaguePoints(league.getLeaguePoints())
                 .wins(league.getWins())
                 .losses(league.getLosses())
-                .summonerId(league.getSummoner().getId())
+                .summoner(league.getSummoner())
                 .build();
     }
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/controller/MatchController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/controller/MatchController.java
@@ -16,8 +16,8 @@ public class MatchController {
 
     private final MatchService matchService;
 
-    @PostMapping("matchlist/{puuid}/save") // 매치 5개 api 불러와서 저장
-    public ResponseEntity<?> createMatch(@PathVariable String puuid) {
+    @PostMapping("/matchlist/{puuid}/save") // 매치 5개 api 불러와서 저장
+    public ResponseEntity<?> createMatch(@PathVariable String puuid) throws InterruptedException {
         matchService.createMatch(puuid);
         return ResponseEntity.ok(HttpStatus.CREATED);
     }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/MatchSummoner.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/MatchSummoner.java
@@ -16,6 +16,7 @@ public class MatchSummoner {
 
     @Id
     @GeneratedValue
+    @Column(name = "match_summoner_pk")
     private Long id;
 
     @ManyToOne

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Participant.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Participant.java
@@ -20,7 +20,7 @@ public class Participant {
     private Long participantPk;
 
     @Column(name = "participant_id")
-    private int participantId; // participant의 PK
+    private int participantId;
 
     ///////////////// summoner ////////////////////////////////////
     @Column(name = "summoner_id")
@@ -36,6 +36,9 @@ public class Participant {
 
     @Column(name = "summoner_level")
     private int summonerLevel;
+
+    @Column(name = "riotIdTagline")
+    private String riotIdTagline;
 
     ////////////////////////////////////////////////////////////
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchDto.java
@@ -1,6 +1,7 @@
 package com.ggwp.searchservice.match.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ggwp.searchservice.account.dto.AccountDto;
 import com.ggwp.searchservice.match.domain.Match;
 import com.ggwp.searchservice.match.domain.Participant;
 import com.ggwp.searchservice.match.domain.Team;
@@ -210,6 +211,9 @@ public class MatchDto {
         @JsonProperty("summonerName")
         private String summonerName;
 
+        //// Account////////////
+        @JsonProperty("riotIdTagline")
+        private String riotIdTagline;
         ////////////////////////////////////////////////////////////
 
         ///////////////////////kda /////////////////////////////////
@@ -317,6 +321,14 @@ public class MatchDto {
                     .name(this.summonerName)
                     .summonerLevel(this.summmonerLevel)
                     .puuid(this.puuid)
+                    .build();
+        }
+
+        public AccountDto createAccountDto() {
+            return AccountDto.builder()
+                    .puuid(this.puuid)
+                    .gameName(this.summonerName)
+                    .tagLine(this.riotIdTagline)
                     .build();
         }
     }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchDto.java
@@ -287,6 +287,7 @@ public class MatchDto {
                     .puuid(this.puuid)
                     .summonerLevel(this.summmonerLevel)
                     .summonerName(this.summonerName)
+                    .riotIdTagline(this.riotIdTagline)
                     .kills(this.kills)
                     .assists(this.assists)
                     .deaths(this.deaths)

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
@@ -1,5 +1,12 @@
 package com.ggwp.searchservice.match.service;
 
+import com.ggwp.searchservice.account.domain.Account;
+import com.ggwp.searchservice.account.dto.AccountDto;
+import com.ggwp.searchservice.account.repository.AccountRepository;
+import com.ggwp.searchservice.league.domain.League;
+import com.ggwp.searchservice.league.dto.ResponseGetLeagueDto;
+import com.ggwp.searchservice.league.feign.LoLToLeagueFeign;
+import com.ggwp.searchservice.league.service.LeagueService;
 import com.ggwp.searchservice.match.MatchRepository.MatchRepository;
 import com.ggwp.searchservice.match.MatchRepository.MatchSummonerRepository;
 import com.ggwp.searchservice.match.domain.Match;
@@ -27,11 +34,15 @@ public class MatchService {
     private final MatchRepository matchRepository;
     private final SummonerRepository summonerRepository;
     private final MatchSummonerRepository matchSummonerRepository;
+    private final LoLToLeagueFeign leagueFeign;
+    private final LeagueService leagueService;
+
+    private final AccountRepository accountRepository;
 
     @Value("${LOL.apikey}")
     private String apiKey;
 
-    public void createMatch(String puuid) {
+    public void createMatch(String puuid) throws InterruptedException {
         List<String> matchIds = matchFeign.getMatchIds(puuid, apiKey); // matchIds 5개 가져오기
 
         for (String matchId : matchIds) { // 5번 반복한다.
@@ -49,13 +60,29 @@ public class MatchService {
             List<MatchSummoner> matchSummonerList = new ArrayList<>(); // matchSummoner를 한 번에 저장해줄 리스트 선언, db에 저장을 한 번에 하기 위함
             for (MatchDto.ParticipantDto participantDto : participantDtoList) {
                 RequestCreateSummonerDto createSummonerDto = participantDto.createSummonerDto();
+                AccountDto accountDto = participantDto.createAccountDto();
+
                 Summoner summoner = createSummonerDto.toEntity();
+
+                List<ResponseGetLeagueDto> leagueDtoList = leagueFeign.getLeagues(participantDto.getSummonerId(), apiKey);
+                List<League> leagueList = new ArrayList<>();
+                for (ResponseGetLeagueDto responseGetLeagueDto : leagueDtoList) {
+                    League league = responseGetLeagueDto.toEntity(summoner);
+                    leagueList.add(league);
+                }
+                summoner.addLeagues(leagueList);
+
+                Account account = accountDto.toEntity(summoner);
+                summoner.addAccount(account);
+
                 // summoner를 저장 하기 전 MatchSummoner를 만들어 summoner에 넣어줘야 한다.
                 MatchSummoner matchSummoner = MatchSummoner.builder()
                         .summoner(summoner)
                         .match(match)
                         .build();
                 summoner.addMatchSummoner(matchSummoner); // summoner에다가 matchsummoner 넣어주기
+
+
                 summonerRepository.save(summoner); // summoner 저장
                 matchSummonerList.add(matchSummoner); // matchSummoner List에다가 저장
             }
@@ -63,6 +90,7 @@ public class MatchService {
             match.addMatchSummoners(matchSummonerList);
 
             matchSummonerRepository.saveAll(matchSummonerList); // matchSummoner List 저장
+            Thread.sleep(1000);
         }
     }
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
@@ -96,7 +96,7 @@ public class MatchService {
 
 
     // 소환사의 matchId들 matchSummoner에서 가져오기
-    @Transactional(readOnly = true)
+
     public List<MatchSummonerDto> getMatchSummonerBySummonerId(String summonerId) {
         List<MatchSummoner> matchSummoners = matchSummonerRepository.findBySummonerId(summonerId);
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/controller/SummonerController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/controller/SummonerController.java
@@ -1,10 +1,13 @@
 package com.ggwp.searchservice.summoner.controller;
+
 import com.ggwp.searchservice.summoner.dto.ResponseGetSummonerDto;
 import com.ggwp.searchservice.summoner.service.SummonerService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,32 +16,15 @@ public class SummonerController {
 
     private final SummonerService summonerService;
 
-    @GetMapping("get/{name}") // 롤 닉네임으로 Summoner 가져오기 USE API
-    public ResponseEntity<?> getSummoner(@PathVariable String name){
-        ResponseGetSummonerDto summonerDto = summonerService.getSummonerAndSave(name);
+    @GetMapping("/get/{puuid}") // 롤 닉네임으로 Summoner 가져오기 USE API
+    public ResponseEntity<?> getSummoner(@PathVariable String puuid) {
+        ResponseGetSummonerDto summonerDto = summonerService.getSummonerAndSave(puuid);
         return ResponseEntity.ok(summonerDto);
     }
 
-    @GetMapping("get/{name}/no-api") // 롤 닉네임으로 Summoner 가져오기 No-API
-    public ResponseEntity<?> getSummonerNoApi(@PathVariable String name){
-        ResponseGetSummonerDto summonerDto = summonerService.getSummonerNoApi(name);
+    @GetMapping("/get/{name}/no-api") // 롤 닉네임으로 Summoner 가져오기 No-API
+    public ResponseEntity<?> getSummonerNoApi(@PathVariable String puuid) {
+        ResponseGetSummonerDto summonerDto = summonerService.getSummonerNoApi(puuid);
         return ResponseEntity.ok(summonerDto);
     }
-
-    // ----------------------------------------------------------------------------
-    // summoner 전체를 가져가서 사용하실지, FK만 가져가서 쓰실 지 몰라서 만들었습니다.
-    // ----------------------------------------------------------------------------
-
-    @GetMapping("get/summoner-id/{name}") // 롤 닉네임으로 Encrypted된 SummonerId 가져오기
-    public ResponseEntity<?> getEncryptedSummonerId(@PathVariable String name){
-        ResponseGetSummonerDto summonerDto = summonerService.getSummonerNoApi(name);
-        return ResponseEntity.ok(summonerDto.getId());
-    }
-
-    @GetMapping("get/puuid/{name}") // 롤 닉네임으로 puuid 가져오기
-    public ResponseEntity<?> getPuuid(@PathVariable String name){
-        ResponseGetSummonerDto summonerDto = summonerService.getSummonerNoApi(name);
-        return ResponseEntity.ok(summonerDto.getPuuid());
-    }
-
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/domain/Summoner.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/domain/Summoner.java
@@ -1,5 +1,6 @@
 package com.ggwp.searchservice.summoner.domain;
 
+import com.ggwp.searchservice.account.domain.Account;
 import com.ggwp.searchservice.league.domain.League;
 import com.ggwp.searchservice.match.domain.MatchSummoner;
 import com.ggwp.searchservice.summoner.dto.ResponseGetSummonerDto;
@@ -37,11 +38,14 @@ public class Summoner {
     private int summonerLevel; // 소환사 레벨
 
     // 리그 연결 일대다 ( 소환사 1 : 리그 2)
-    @OneToMany(mappedBy = "summoner")
+    @OneToMany(mappedBy = "summoner", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<League> leagues;
 
     @OneToMany(mappedBy = "summoner", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<MatchSummoner> matchSummoners = new ArrayList<>();
+
+    @OneToOne(mappedBy = "summoner", cascade = CascadeType.ALL)
+    private Account account;
 
     // 소환사 Entity를 -> DTO로 변경
     public ResponseGetSummonerDto toDto(Summoner summoner) {
@@ -69,5 +73,17 @@ public class Summoner {
         this.matchSummoners.add(matchSummoner);
 
         // 이미 값이 담겨있다고 가정하고, 따로 연관관계 설정이 필요하지 않음
+    }
+
+    public void addAccount(Account account) {
+        this.account = account;
+    }
+
+    public void addLeagues(List<League> leagueList) {
+        Hibernate.initialize(this.leagues);
+        if (this.leagues == null) {
+            this.leagues = new ArrayList<>();
+        }
+        this.leagues.addAll(leagueList);
     }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/dto/RequestCreateSummonerDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/dto/RequestCreateSummonerDto.java
@@ -1,5 +1,7 @@
 package com.ggwp.searchservice.summoner.dto;
 
+import com.ggwp.searchservice.account.domain.Account;
+import com.ggwp.searchservice.league.domain.League;
 import com.ggwp.searchservice.summoner.domain.Summoner;
 import lombok.*;
 
@@ -25,7 +27,9 @@ public class RequestCreateSummonerDto {
 
     private int summonerLevel;
 
-    //    private String accountId;
+    private Account account;
+
+    private League league;
 
     // DTO를 -> Entity 로 변경
     public Summoner toEntity() {

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/feign/LOLToSummonerFeign.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/feign/LOLToSummonerFeign.java
@@ -8,10 +8,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "lol-summoner", url = "https://kr.api.riotgames.com/lol/")
 public interface LOLToSummonerFeign {
-    // api key를 이용하여 소환사의 정보 가져오기
-    @GetMapping("summoner/v4/summoners/by-name/{summonerName}")
-    ResponseGetSummonerDto getSummoner(
-            @PathVariable String summonerName,
+    @GetMapping("summoner/v4/summoners/by-puuid/{puuid}")
+    ResponseGetSummonerDto getSummonerByPuuid(
+            @PathVariable String puuid,
             @RequestParam("api_key") String apiKey
     );
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/repository/SummonerRepository.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/repository/SummonerRepository.java
@@ -11,6 +11,8 @@ public interface SummonerRepository extends JpaRepository<Summoner, Long> {
 
     Summoner findSummonerById(String id);
 
+    boolean existsByPuuid(String puuid);
+
     boolean existsById(String id);
 
     Summoner findSummonerByPuuid(String puuid);

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerService.java
@@ -16,19 +16,18 @@ public class SummonerService {
     @Value("${LOL.apikey}")
     private String apiKey;
 
-    // 롤 api를 통해서 소환사 정보 가져오기 및 DB 저장
-    public ResponseGetSummonerDto getSummonerAndSave(String name) {
-        ResponseGetSummonerDto summonerDto = summonerFeign.getSummoner(name, apiKey);
+    // 롤 api를 통해서 소환사 정보 가져오기 및 DB 저장 USE API
+    public ResponseGetSummonerDto getSummonerAndSave(String puuid) {
+        ResponseGetSummonerDto summonerDto = summonerFeign.getSummonerByPuuid(puuid, apiKey);
         Summoner summoner = summonerDto.toEntity();
         summonerRepository.save(summoner);
         return summonerDto;
     }
 
-    // DB에 저장한 소환사 정보 가져오기
-    public ResponseGetSummonerDto getSummonerNoApi(String name) {
-        Summoner summoner = summonerRepository.findSummonerByName(name);
-        ResponseGetSummonerDto summonerDto = summoner.toDto(summoner);
-        return summonerDto;
+    // DB에 저장한 소환사 정보 가져오기 No-API
+    public ResponseGetSummonerDto getSummonerNoApi(String puuid) {
+        Summoner summoner = summonerRepository.findSummonerByPuuid(puuid);
+        return summoner.toDto(summoner);
     }
 
 }

--- a/Search-service/src/main/resources/application-dev.yml
+++ b/Search-service/src/main/resources/application-dev.yml
@@ -13,7 +13,7 @@ spring:
   # jpa
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/Search-service/src/main/resources/application-dev.yml
+++ b/Search-service/src/main/resources/application-dev.yml
@@ -13,7 +13,7 @@ spring:
   # jpa
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
[백엔드] 롤 네임태그 추가
- Account 엔티티 추가
- Summoner와 League, Account 연관 매핑

match api 호출하면 5개의 매치와 50명의 소환사 50명의 리그, db 저장
1초 api 호출이 많아서 강제로 쓰레드 1초 슬립