### PR TITLE
Refactor: 전적 서비스 리팩토링2

### DIFF
--- a/Search-service/build.gradle
+++ b/Search-service/build.gradle
@@ -23,11 +23,14 @@ repositories {
 
 ext {
     set('springCloudVersion', "2022.0.4")
+    queryDslVersion = "5.0.0"
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.jetbrains:annotations:24.0.0'
+    implementation 'org.jetbrains:annotations:24.0.0'
 //    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
     compileOnly 'org.projectlombok:lombok'
@@ -35,19 +38,46 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     // feign
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-openfeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.4'
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-}
+    //querydsl 설정 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+}
 dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
 }
 
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+

--- a/Search-service/src/main/generated/com/ggwp/searchservice/account/domain/QAccount.java
+++ b/Search-service/src/main/generated/com/ggwp/searchservice/account/domain/QAccount.java
@@ -1,0 +1,55 @@
+package com.ggwp.searchservice.account.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QAccount is a Querydsl query type for Account
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAccount extends EntityPathBase<Account> {
+
+    private static final long serialVersionUID = -178999123L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QAccount account = new QAccount("account");
+
+    public final StringPath gameName = createString("gameName");
+
+    public final StringPath puuid = createString("puuid");
+
+    public final com.ggwp.searchservice.summoner.domain.QSummoner summoner;
+
+    public final StringPath tagLine = createString("tagLine");
+
+    public QAccount(String variable) {
+        this(Account.class, forVariable(variable), INITS);
+    }
+
+    public QAccount(Path<? extends Account> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QAccount(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QAccount(PathMetadata metadata, PathInits inits) {
+        this(Account.class, metadata, inits);
+    }
+
+    public QAccount(Class<? extends Account> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.summoner = inits.isInitialized("summoner") ? new com.ggwp.searchservice.summoner.domain.QSummoner(forProperty("summoner"), inits.get("summoner")) : null;
+    }
+
+}
+

--- a/Search-service/src/main/generated/com/ggwp/searchservice/league/domain/QLeague.java
+++ b/Search-service/src/main/generated/com/ggwp/searchservice/league/domain/QLeague.java
@@ -1,0 +1,65 @@
+package com.ggwp.searchservice.league.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLeague is a Querydsl query type for League
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLeague extends EntityPathBase<League> {
+
+    private static final long serialVersionUID = -976634013L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLeague league = new QLeague("league");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath leagueId = createString("leagueId");
+
+    public final NumberPath<Integer> leaguePoints = createNumber("leaguePoints", Integer.class);
+
+    public final NumberPath<Integer> losses = createNumber("losses", Integer.class);
+
+    public final StringPath queueType = createString("queueType");
+
+    public final StringPath ranks = createString("ranks");
+
+    public final com.ggwp.searchservice.summoner.domain.QSummoner summoner;
+
+    public final StringPath tier = createString("tier");
+
+    public final NumberPath<Integer> wins = createNumber("wins", Integer.class);
+
+    public QLeague(String variable) {
+        this(League.class, forVariable(variable), INITS);
+    }
+
+    public QLeague(Path<? extends League> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLeague(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLeague(PathMetadata metadata, PathInits inits) {
+        this(League.class, metadata, inits);
+    }
+
+    public QLeague(Class<? extends League> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.summoner = inits.isInitialized("summoner") ? new com.ggwp.searchservice.summoner.domain.QSummoner(forProperty("summoner"), inits.get("summoner")) : null;
+    }
+
+}
+

--- a/Search-service/src/main/generated/com/ggwp/searchservice/match/domain/QMatch.java
+++ b/Search-service/src/main/generated/com/ggwp/searchservice/match/domain/QMatch.java
@@ -1,0 +1,54 @@
+package com.ggwp.searchservice.match.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMatch is a Querydsl query type for Match
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMatch extends EntityPathBase<Match> {
+
+    private static final long serialVersionUID = -1684939283L;
+
+    public static final QMatch match = new QMatch("match");
+
+    public final NumberPath<Long> gameCreation = createNumber("gameCreation", Long.class);
+
+    public final NumberPath<Long> gameDuration = createNumber("gameDuration", Long.class);
+
+    public final NumberPath<Long> gameEndTimestamp = createNumber("gameEndTimestamp", Long.class);
+
+    public final NumberPath<Long> gameStartTimestamp = createNumber("gameStartTimestamp", Long.class);
+
+    public final StringPath matchId = createString("matchId");
+
+    public final ListPath<MatchSummoner, QMatchSummoner> matchSummoners = this.<MatchSummoner, QMatchSummoner>createList("matchSummoners", MatchSummoner.class, QMatchSummoner.class, PathInits.DIRECT2);
+
+    public final StringPath platformId = createString("platformId");
+
+    public final EnumPath<com.ggwp.searchservice.common.enums.GameMode> queueId = createEnum("queueId", com.ggwp.searchservice.common.enums.GameMode.class);
+
+    public final ListPath<Team, QTeam> teams = this.<Team, QTeam>createList("teams", Team.class, QTeam.class, PathInits.DIRECT2);
+
+    public QMatch(String variable) {
+        super(Match.class, forVariable(variable));
+    }
+
+    public QMatch(Path<? extends Match> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMatch(PathMetadata metadata) {
+        super(Match.class, metadata);
+    }
+
+}
+

--- a/Search-service/src/main/generated/com/ggwp/searchservice/match/domain/QMatchSummoner.java
+++ b/Search-service/src/main/generated/com/ggwp/searchservice/match/domain/QMatchSummoner.java
@@ -1,0 +1,54 @@
+package com.ggwp.searchservice.match.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMatchSummoner is a Querydsl query type for MatchSummoner
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMatchSummoner extends EntityPathBase<MatchSummoner> {
+
+    private static final long serialVersionUID = 1831771739L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMatchSummoner matchSummoner = new QMatchSummoner("matchSummoner");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMatch match;
+
+    public final com.ggwp.searchservice.summoner.domain.QSummoner summoner;
+
+    public QMatchSummoner(String variable) {
+        this(MatchSummoner.class, forVariable(variable), INITS);
+    }
+
+    public QMatchSummoner(Path<? extends MatchSummoner> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMatchSummoner(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMatchSummoner(PathMetadata metadata, PathInits inits) {
+        this(MatchSummoner.class, metadata, inits);
+    }
+
+    public QMatchSummoner(Class<? extends MatchSummoner> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.match = inits.isInitialized("match") ? new QMatch(forProperty("match")) : null;
+        this.summoner = inits.isInitialized("summoner") ? new com.ggwp.searchservice.summoner.domain.QSummoner(forProperty("summoner"), inits.get("summoner")) : null;
+    }
+
+}
+

--- a/Search-service/src/main/generated/com/ggwp/searchservice/match/domain/QParticipant.java
+++ b/Search-service/src/main/generated/com/ggwp/searchservice/match/domain/QParticipant.java
@@ -1,0 +1,115 @@
+package com.ggwp.searchservice.match.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QParticipant is a Querydsl query type for Participant
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QParticipant extends EntityPathBase<Participant> {
+
+    private static final long serialVersionUID = 84424027L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QParticipant participant = new QParticipant("participant");
+
+    public final NumberPath<Integer> assists = createNumber("assists", Integer.class);
+
+    public final NumberPath<Integer> champExperience = createNumber("champExperience", Integer.class);
+
+    public final NumberPath<Integer> championId = createNumber("championId", Integer.class);
+
+    public final StringPath championName = createString("championName");
+
+    public final NumberPath<Integer> champLevel = createNumber("champLevel", Integer.class);
+
+    public final NumberPath<Integer> deaths = createNumber("deaths", Integer.class);
+
+    public final NumberPath<Integer> item0 = createNumber("item0", Integer.class);
+
+    public final NumberPath<Integer> item1 = createNumber("item1", Integer.class);
+
+    public final NumberPath<Integer> item2 = createNumber("item2", Integer.class);
+
+    public final NumberPath<Integer> item3 = createNumber("item3", Integer.class);
+
+    public final NumberPath<Integer> item4 = createNumber("item4", Integer.class);
+
+    public final NumberPath<Integer> item5 = createNumber("item5", Integer.class);
+
+    public final NumberPath<Integer> item6 = createNumber("item6", Integer.class);
+
+    public final NumberPath<Integer> kills = createNumber("kills", Integer.class);
+
+    public final NumberPath<Integer> neutralMinionsKilled = createNumber("neutralMinionsKilled", Integer.class);
+
+    public final NumberPath<Integer> participantId = createNumber("participantId", Integer.class);
+
+    public final NumberPath<Long> participantPk = createNumber("participantPk", Long.class);
+
+    public final StringPath primaryDescription = createString("primaryDescription");
+
+    public final StringPath primaryStyle = createString("primaryStyle");
+
+    public final NumberPath<Integer> profileIcon = createNumber("profileIcon", Integer.class);
+
+    public final StringPath puuid = createString("puuid");
+
+    public final StringPath riotIdTagline = createString("riotIdTagline");
+
+    public final StringPath subDescription = createString("subDescription");
+
+    public final StringPath subStyle = createString("subStyle");
+
+    public final NumberPath<Integer> summoner1Id = createNumber("summoner1Id", Integer.class);
+
+    public final NumberPath<Integer> summoner2Id = createNumber("summoner2Id", Integer.class);
+
+    public final StringPath summonerId = createString("summonerId");
+
+    public final NumberPath<Integer> summonerLevel = createNumber("summonerLevel", Integer.class);
+
+    public final StringPath summonerName = createString("summonerName");
+
+    public final QTeam team;
+
+    public final StringPath teamPosition = createString("teamPosition");
+
+    public final NumberPath<Integer> totalDamageDealtToChampions = createNumber("totalDamageDealtToChampions", Integer.class);
+
+    public final NumberPath<Integer> totalDamageTaken = createNumber("totalDamageTaken", Integer.class);
+
+    public final NumberPath<Integer> totalMinionsKilled = createNumber("totalMinionsKilled", Integer.class);
+
+    public QParticipant(String variable) {
+        this(Participant.class, forVariable(variable), INITS);
+    }
+
+    public QParticipant(Path<? extends Participant> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QParticipant(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QParticipant(PathMetadata metadata, PathInits inits) {
+        this(Participant.class, metadata, inits);
+    }
+
+    public QParticipant(Class<? extends Participant> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.team = inits.isInitialized("team") ? new QTeam(forProperty("team"), inits.get("team")) : null;
+    }
+
+}
+

--- a/Search-service/src/main/generated/com/ggwp/searchservice/match/domain/QTeam.java
+++ b/Search-service/src/main/generated/com/ggwp/searchservice/match/domain/QTeam.java
@@ -1,0 +1,57 @@
+package com.ggwp.searchservice.match.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QTeam is a Querydsl query type for Team
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTeam extends EntityPathBase<Team> {
+
+    private static final long serialVersionUID = -1716709067L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QTeam team = new QTeam("team");
+
+    public final QMatch match;
+
+    public final ListPath<Participant, QParticipant> participants = this.<Participant, QParticipant>createList("participants", Participant.class, QParticipant.class, PathInits.DIRECT2);
+
+    public final NumberPath<Integer> teamId = createNumber("teamId", Integer.class);
+
+    public final NumberPath<Long> teamPk = createNumber("teamPk", Long.class);
+
+    public final BooleanPath win = createBoolean("win");
+
+    public QTeam(String variable) {
+        this(Team.class, forVariable(variable), INITS);
+    }
+
+    public QTeam(Path<? extends Team> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QTeam(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QTeam(PathMetadata metadata, PathInits inits) {
+        this(Team.class, metadata, inits);
+    }
+
+    public QTeam(Class<? extends Team> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.match = inits.isInitialized("match") ? new QMatch(forProperty("match")) : null;
+    }
+
+}
+

--- a/Search-service/src/main/generated/com/ggwp/searchservice/summoner/domain/QSummoner.java
+++ b/Search-service/src/main/generated/com/ggwp/searchservice/summoner/domain/QSummoner.java
@@ -1,0 +1,65 @@
+package com.ggwp.searchservice.summoner.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSummoner is a Querydsl query type for Summoner
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSummoner extends EntityPathBase<Summoner> {
+
+    private static final long serialVersionUID = 663182433L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSummoner summoner = new QSummoner("summoner");
+
+    public final com.ggwp.searchservice.account.domain.QAccount account;
+
+    public final StringPath id = createString("id");
+
+    public final ListPath<com.ggwp.searchservice.league.domain.League, com.ggwp.searchservice.league.domain.QLeague> leagues = this.<com.ggwp.searchservice.league.domain.League, com.ggwp.searchservice.league.domain.QLeague>createList("leagues", com.ggwp.searchservice.league.domain.League.class, com.ggwp.searchservice.league.domain.QLeague.class, PathInits.DIRECT2);
+
+    public final ListPath<com.ggwp.searchservice.match.domain.MatchSummoner, com.ggwp.searchservice.match.domain.QMatchSummoner> matchSummoners = this.<com.ggwp.searchservice.match.domain.MatchSummoner, com.ggwp.searchservice.match.domain.QMatchSummoner>createList("matchSummoners", com.ggwp.searchservice.match.domain.MatchSummoner.class, com.ggwp.searchservice.match.domain.QMatchSummoner.class, PathInits.DIRECT2);
+
+    public final StringPath name = createString("name");
+
+    public final NumberPath<Integer> profileIconId = createNumber("profileIconId", Integer.class);
+
+    public final StringPath puuid = createString("puuid");
+
+    public final NumberPath<Long> revisionDate = createNumber("revisionDate", Long.class);
+
+    public final NumberPath<Integer> summonerLevel = createNumber("summonerLevel", Integer.class);
+
+    public QSummoner(String variable) {
+        this(Summoner.class, forVariable(variable), INITS);
+    }
+
+    public QSummoner(Path<? extends Summoner> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSummoner(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSummoner(PathMetadata metadata, PathInits inits) {
+        this(Summoner.class, metadata, inits);
+    }
+
+    public QSummoner(Class<? extends Summoner> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.account = inits.isInitialized("account") ? new com.ggwp.searchservice.account.domain.QAccount(forProperty("account"), inits.get("account")) : null;
+    }
+
+}
+

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/controller/AccountController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/controller/AccountController.java
@@ -2,8 +2,8 @@ package com.ggwp.searchservice.account.controller;
 
 import com.ggwp.searchservice.account.dto.ResponseAccountDto;
 import com.ggwp.searchservice.account.service.AccountService;
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.common.dto.ResponseDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,15 +21,9 @@ public class AccountController {
 
     private final AccountService accountService;
 
-//    @PostMapping("/create")
-//    @Operation(summary = "Account 생성", description = "lol api 호출")
-//    public ResponseDto<String> createAccount(@Valid @RequestBody TokenDto tokenDto) { // 토큰에서 닉네임과 태그를 받는다. (토큰 받으면 수정)
-//        return accountService.createAccount(tokenDto);
-//    }
-
     @PostMapping("/get")
     @Operation(summary = "Account 조회", description = "DB에서 조회")
-    public ResponseDto<ResponseAccountDto> getAccount(@Valid @RequestBody TokenDto tokenDto) { // DB에서 조회
-        return ResponseDto.success(accountService.getAccount(tokenDto));
+    public ResponseDto<ResponseAccountDto> getAccount(@Valid @RequestBody FrontDto frontDto) { // DB에서 조회
+        return ResponseDto.success(accountService.getAccount(frontDto));
     }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/domain/Account.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/domain/Account.java
@@ -1,17 +1,22 @@
 package com.ggwp.searchservice.account.domain;
 
+import com.ggwp.searchservice.account.dto.FeignAccountDto;
 import com.ggwp.searchservice.summoner.domain.Summoner;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Data
 @NoArgsConstructor
 @Builder
 @AllArgsConstructor
+@DynamicUpdate
+@DynamicInsert
 public class Account {
 
     @Id
@@ -24,8 +29,15 @@ public class Account {
     @Column(nullable = true) // - Null일 수 있다.
     private String tagLine; // 롤 태그
 
-    @OneToOne // ( 계정과 소환사는 1:1 관계이다.)
-    @JoinColumn(name = "account")
+    @OneToOne // (계정과 소환사는 1:1 관계이다.)
+    @JoinColumn(name = "summoner_id")
     private Summoner summoner;
 
+    @Version
+    private int version;
+
+    public void updateAccount(FeignAccountDto accountDto) {
+        this.gameName = accountDto.getGameName();
+        this.tagLine = accountDto.getTagLine();
+    }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/feign/LOLToAccountFeign.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/feign/LOLToAccountFeign.java
@@ -17,4 +17,9 @@ public interface LOLToAccountFeign {
             @RequestParam("api_key") String apiKey
     );
 
+    @GetMapping("account/v1/accounts/by-puuid/{puuid}")
+    Optional<FeignAccountDto> getAccountByPuuid(
+            @PathVariable String puuid,
+            @RequestParam("api_key") String apiKey
+    );
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/repository/AccountRepository.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/repository/AccountRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
-    Optional<Account> findByGameNameAndTagLine(String gameName, String tagLine);
+    Optional<Account> findAccountByGameNameAndTagLine(String gameName, String tagLine);
 
     boolean existsByGameNameAndTagLine(String gameName, String tagLine);
+
+    Account findAccountByPuuid(String puuid);
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/account/service/AccountService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/account/service/AccountService.java
@@ -2,25 +2,20 @@ package com.ggwp.searchservice.account.service;
 
 import com.ggwp.searchservice.account.domain.Account;
 import com.ggwp.searchservice.account.dto.CreateAccountDto;
-import com.ggwp.searchservice.account.dto.FeignAccountDto;
 import com.ggwp.searchservice.account.dto.ResponseAccountDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.summoner.domain.Summoner;
 
 public interface AccountService {
 
-    ResponseAccountDto getAccount(TokenDto tokenDto);
+    ResponseAccountDto updateAccount(CreateAccountDto createAccountDto);
 
-    Account findAccount(TokenDto tokenDto);
+    String existAccount(FrontDto frontDto);
 
     Account createAccount(CreateAccountDto createAccountDto, Summoner summoner);
 
-    FeignAccountDto feignAccount(TokenDto tokenDto);
+    Account findAccount(FrontDto frontDto);
 
-    ResponseAccountDto toDto(Account account);
-
-    Account toEntity(CreateAccountDto createAccountDto, Summoner summoner);
-
-    String existAccount(TokenDto tokenDto);
+    ResponseAccountDto getAccount(FrontDto frontDto);
 
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/common/dto/FrontDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/common/dto/FrontDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
-public class TokenDto {
+public class FrontDto {
 
     @NotBlank(message = "이름은 비워 둘 수 없습니다")
     @Size(max = 63, message = "이름은 63자를 초과할 수 없습니다")

--- a/Search-service/src/main/java/com/ggwp/searchservice/common/enums/GameMode.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/common/enums/GameMode.java
@@ -15,4 +15,13 @@ public enum GameMode {
     private final int queueId;
     private final String description;
 
+    public static GameMode getByQueueId(int queueId) {
+        for (GameMode gameMode : GameMode.values()) {
+            if (gameMode.queueId == queueId) {
+                return gameMode;
+            }
+        }
+        throw new IllegalArgumentException("No matching constant for queueId: " + queueId);
+    }
+
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/common/enums/RuneEnums.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/common/enums/RuneEnums.java
@@ -17,4 +17,13 @@ public enum RuneEnums {
     private final String icon;
     private final String name;
 
+    public static RuneEnums getById(int id) {
+        for (RuneEnums rune : RuneEnums.values()) {
+            if (rune.getId() == id) {
+                return rune;
+            }
+        }
+        throw new IllegalArgumentException("No matching constant for id: " + id);
+    }
+
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/common/exception/CustomException.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/common/exception/CustomException.java
@@ -1,5 +1,6 @@
 package com.ggwp.searchservice.common.exception;
 
+import feign.FeignException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -8,4 +9,11 @@ import lombok.RequiredArgsConstructor;
 public class CustomException extends RuntimeException {
 
     private final ErrorCode errorCode;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class FeignClientError extends RuntimeException {
+        private final FeignException feignException;
+        private final ErrorCode errorCode;
+    }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/common/exception/ErrorCode.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/common/exception/ErrorCode.java
@@ -8,19 +8,27 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    AccountAfterSummonerCreation(HttpStatus.BAD_GATEWAY, "비정상적인 접근입니다. Account는 소환사가 생성한 이후에 생성됩니다."),
+    AccountAfterSummonerCreation(HttpStatus.BAD_REQUEST, "비정상적인 접근입니다. Account는 소환사가 생성한 이후에 생성됩니다."),
 
     NotFindAccount(HttpStatus.NOT_FOUND, "Account를 찾을 수 없습니다."),
 
-    NotFeignAccount(HttpStatus.NOT_FOUND, "Account Feign한 값을 받지 못했습니다."),
+    NotfeignAccountByNameAndTag(HttpStatus.NOT_FOUND, "Account Feign한 값을 받지 못했습니다."),
+
+    NotfeignAccountByPuuid(HttpStatus.NOT_FOUND, "Account Feign한 값을 받지 못했습니다."),
 
     NotFeignMatchIds(HttpStatus.NOT_FOUND, "matchId Feign한 값을 받지 못했습니다"),
+
     NotFeignMatch(HttpStatus.NOT_FOUND, "Match Feign한 값을 받지 못했습니다."),
+
     NotFindSummoner(HttpStatus.NOT_FOUND, "Summoner를 찾을 수 없습니다."),
 
     NotFindLeagues(HttpStatus.NOT_FOUND, "Leagues를 찾을 수 없습니다."),
 
+    InValidException(HttpStatus.BAD_REQUEST, "Valid 값이 잘못되었습니다."),
+
+    NotFeginException(HttpStatus.BAD_REQUEST, "Fegin을 하지 못했습니다."),
     NotFindParticipants(HttpStatus.NOT_FOUND, "Participants를 찾을 수 없습니다.");
+
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/common/exception/GlobalExceptionHandler.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,15 @@
 package com.ggwp.searchservice.common.exception;
 
 import com.ggwp.searchservice.common.dto.ResponseDto;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -12,5 +18,21 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ResponseDto.Error> handlerException(CustomException e) {
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(new ResponseDto.Error(e.getErrorCode().getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto.Error> validationException(MethodArgumentNotValidException e) {
+        List<String> errors = e.getBindingResult().getFieldErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .toList();
+        return ResponseEntity.status(ErrorCode.InValidException.getHttpStatus())
+                .body(new ResponseDto.Error(errors.get(0)));
+    }
+
+    @ExceptionHandler(CustomException.FeignClientError.class)
+    public ResponseEntity<ResponseDto.Error> excelErrorException(CustomException.FeignClientError e) {
+        return ResponseEntity.status(ErrorCode.NotFeginException.getHttpStatus())
+                .body(new ResponseDto.Error("Feign Exception: " + e.getFeignException().getMessage()));
     }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/league/controller/LeagueController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/league/controller/LeagueController.java
@@ -1,8 +1,8 @@
 package com.ggwp.searchservice.league.controller;
 
 
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.common.dto.ResponseDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
 import com.ggwp.searchservice.league.dto.ResponseLeagueDto;
 import com.ggwp.searchservice.league.service.LeagueServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,8 +26,8 @@ public class LeagueController {
 
     @PostMapping("/get")
     @Operation(summary = "League (랭크 조회)", description = "DB로 조회")
-    public ResponseDto<List<ResponseLeagueDto>> getLeague(@Valid @RequestBody TokenDto tokenDto) {
-        return leagueService.getLeague(tokenDto);
+    public ResponseDto<List<ResponseLeagueDto>> getLeague(@Valid @RequestBody FrontDto frontDto) {
+        return ResponseDto.success(leagueService.getLeague(frontDto));
     }
 
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/league/domain/League.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/league/domain/League.java
@@ -8,12 +8,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Builder
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@DynamicUpdate
+@DynamicInsert
 public class League {
 
     @Id
@@ -34,6 +38,9 @@ public class League {
     private int wins; // 승리
     @Column(nullable = false)
     private int losses; // 패배
+
+    @Version
+    private int version;
 
     // 다대일 연결 ( 리그 2 : 소환사 1)
     @ManyToOne

--- a/Search-service/src/main/java/com/ggwp/searchservice/league/repository/LeagueRepository.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/league/repository/LeagueRepository.java
@@ -11,5 +11,4 @@ public interface LeagueRepository extends JpaRepository<League, Long> {
 
     Optional<List<League>> findLeaguesBySummonerId(String summonerId);
 
-    boolean existsByQueueTypeAndSummoner_Puuid(String queueType, String puuid);
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/league/service/LeagueService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/league/service/LeagueService.java
@@ -1,26 +1,16 @@
 package com.ggwp.searchservice.league.service;
 
-import com.ggwp.searchservice.common.dto.ResponseDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.league.domain.League;
-import com.ggwp.searchservice.league.dto.CreateLeagueDto;
 import com.ggwp.searchservice.league.dto.ResponseLeagueDto;
 import com.ggwp.searchservice.summoner.domain.Summoner;
 
 import java.util.List;
 
 public interface LeagueService {
-    ResponseDto<List<ResponseLeagueDto>> getLeague(TokenDto tokenDto); // 토큰으로 리그 얻기
-
-    List<League> findLeagues(Summoner summoner); // 리그 엔티티 가져오기
-
-    List<ResponseLeagueDto> leagueToDto(List<League> leagueList); // 리그 엔티티 -> DTO로 바꾸기
-
-    List<CreateLeagueDto> leagueFeign(Summoner summoner);
-
-    League LeaguetoEntity(CreateLeagueDto leagueDto, Summoner summoner);
-
     List<League> createLeague(Summoner summoner);
 
     void updateLeagues(Summoner summoner);
+
+    List<ResponseLeagueDto> getLeague(FrontDto frontDto);
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/league/service/LeagueServiceImpl.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/league/service/LeagueServiceImpl.java
@@ -3,8 +3,7 @@ package com.ggwp.searchservice.league.service;
 
 import com.ggwp.searchservice.account.domain.Account;
 import com.ggwp.searchservice.account.service.AccountService;
-import com.ggwp.searchservice.common.dto.ResponseDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.common.exception.CustomException;
 import com.ggwp.searchservice.common.exception.ErrorCode;
 import com.ggwp.searchservice.league.domain.League;
@@ -17,64 +16,76 @@ import com.ggwp.searchservice.summoner.service.SummonerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class LeagueServiceImpl implements LeagueService {
-
+    // 레포지토리
     private final LeagueRepository leagueRepository;
+    // 페인
     private final LoLToLeagueFeign leagueFeign;
+    // 서비스
     private final AccountService accountService;
     private final SummonerService summonerService;
 
     @Value("${LOL.apikey}")
     private String apiKey;
 
-    public List<CreateLeagueDto> leagueFeign(Summoner summoner) {
+    private List<CreateLeagueDto> leagueFeign(Summoner summoner) {
         return leagueFeign.getLeagues(summoner.getId(), apiKey);
     }
 
     @Override
+    @Transactional
     public List<League> createLeague(Summoner summoner) {
         List<League> leagueList = new ArrayList<>();
         List<CreateLeagueDto> leagueDtoList = leagueFeign(summoner);
 
         for (CreateLeagueDto createLeagueDto : leagueDtoList) {
-            leagueList.add(leagueRepository.save(LeaguetoEntity(createLeagueDto, summoner)));
+            leagueList.add(leagueRepository.save(leaguetoEntity(createLeagueDto, summoner)));
         }
         return leagueList;
     }
 
+    @Override
+    @Transactional
     public void updateLeagues(Summoner summoner) {
+        List<League> leagueList = findLeagues(summoner);
         List<CreateLeagueDto> leagueDtoList = leagueFeign(summoner);
-        for (CreateLeagueDto createLeagueDto : leagueDtoList) {
-            leagueRepository.save(LeaguetoEntity(createLeagueDto, summoner));
-        }
 
+        for (League league : leagueList) {
+            for (CreateLeagueDto createLeagueDto : leagueDtoList) {
+                if (createLeagueDto.getQueueType().equals(league.getQueueType())) {
+                    league.updateLeague(createLeagueDto);
+                }
+            }
+        }
     }
 
     // 리그 정보 얻기 No - API
-    public ResponseDto<List<ResponseLeagueDto>> getLeague(TokenDto tokenDto) {
+    @Override
+    @Transactional(readOnly = true)
+    public List<ResponseLeagueDto> getLeague(FrontDto frontDto) {
 
-        Account account = accountService.findAccount(tokenDto); // 토크으로 Account
+        Account account = accountService.findAccount(frontDto); // 토크으로 Account
         Summoner summoner = summonerService.findSummoner(account); // Summoner 가져오기
 
         List<League> leagueList = findLeagues(summoner); // 리그 가져오기
 
-        return ResponseDto.success(leagueToDto(leagueList));
+        return leagueToDto(leagueList);
     }
 
-    @Override // find League Entity
-    public List<League> findLeagues(Summoner summoner) {
+    private List<League> findLeagues(Summoner summoner) {
         return leagueRepository.findLeaguesBySummonerId(summoner.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NotFindLeagues));
     }
 
-    @Override // League Entity -> DTO
-    public List<ResponseLeagueDto> leagueToDto(List<League> leagueList) {
+    private List<ResponseLeagueDto> leagueToDto(List<League> leagueList) {
         List<ResponseLeagueDto> leagueDtoList = new ArrayList<>();
         for (League league : leagueList) {
             ResponseLeagueDto leagueDto = league.toDto(league);
@@ -83,8 +94,7 @@ public class LeagueServiceImpl implements LeagueService {
         return leagueDtoList;
     }
 
-    @Override
-    public League LeaguetoEntity(CreateLeagueDto leagueDto, Summoner summoner) {
+    private League leaguetoEntity(CreateLeagueDto leagueDto, Summoner summoner) {
         return League.builder()
                 .leagueId(leagueDto.getLeagueId())
                 .queueType(leagueDto.getQueueType())

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/controller/MatchController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/controller/MatchController.java
@@ -1,11 +1,13 @@
 package com.ggwp.searchservice.match.controller;
 
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.common.dto.ResponseDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
 import com.ggwp.searchservice.match.dto.MatchDto;
+import com.ggwp.searchservice.match.dto.RequestPageDto;
 import com.ggwp.searchservice.match.service.MatchServiceImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,13 +23,19 @@ public class MatchController {
     private final MatchServiceImpl matchService;
 
     @PostMapping("/create") // 매치 5개 api 불러와서 저장
-    public ResponseDto<String> createMatch(@Valid @RequestBody TokenDto tokenDto) throws InterruptedException {
-        matchService.createMatches(tokenDto);
+    public ResponseDto<String> createMatch(@Valid @RequestBody FrontDto frontDto) throws InterruptedException {
+        matchService.createMatches(frontDto);
         return ResponseDto.success("Create Matches!");
     }
 
     @PostMapping("/get")
-    public ResponseDto<List<MatchDto>> getMatchList(@Valid @RequestBody TokenDto tokenDto) {
-        return ResponseDto.success(matchService.getMatchList(tokenDto));
+    public ResponseDto<List<MatchDto>> getMatchList(@Valid @RequestBody FrontDto frontDto) {
+        return ResponseDto.success(matchService.getMatchList(frontDto));
     }
+
+    @PostMapping("/get/pages") // 페이징 임시..
+    public ResponseDto<Page<MatchDto>> getMatchPages(@Valid @RequestBody FrontDto frontDto, RequestPageDto.Search pageDto) {
+        return ResponseDto.success(matchService.pagedMatches(frontDto, pageDto));
+    }
+
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Match.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Match.java
@@ -1,11 +1,13 @@
 package com.ggwp.searchservice.match.domain;
 
+import com.ggwp.searchservice.common.enums.GameMode;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.Hibernate;
+import org.hibernate.annotations.DynamicInsert;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +18,7 @@ import java.util.List;
 @Builder
 @Getter
 @Table(name = "matches")
+@DynamicInsert
 public class Match {
 
     @Id
@@ -24,8 +27,12 @@ public class Match {
     @Column(name = "platform_id", nullable = false)
     private String platformId; // KR
 
+//    @Column(name = "queue_id", nullable = false)
+//    private int queueId; // 게임 모드
+
     @Column(name = "queue_id", nullable = false)
-    private int queueId; // 게임 모드
+    @Enumerated(EnumType.STRING)
+    private GameMode queueId; // 게임 모드
 
     @Column(name = "game_creation", nullable = false)
     private long gameCreation; // 게임 생성 시각
@@ -40,10 +47,10 @@ public class Match {
     private long gameStartTimestamp; // 게임 시작 시각
 
     @OneToMany(mappedBy = "match", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    private List<Team> teams = new ArrayList<>();
+    private List<Team> teams;
 
     @OneToMany(mappedBy = "match", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    private List<MatchSummoner> matchSummoners = new ArrayList<>();
+    private List<MatchSummoner> matchSummoners;
 
     public void addTeams(List<Team> teams) {
         this.teams.addAll(teams);

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/MatchSummoner.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/MatchSummoner.java
@@ -6,12 +6,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
+@DynamicInsert
 public class MatchSummoner {
 
     @Id

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Participant.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Participant.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
+@DynamicInsert
 public class Participant {
 
     @Id
@@ -83,12 +85,16 @@ public class Participant {
     private int totalDamageTaken; // 총 탱량
     @Column(nullable = false)
     private String teamPosition;
+    @Column(name = "primary_description", nullable = false)
+    private String primaryDescription;
+    @Column(name = "sub_description", nullable = false)
+    private String subDescription;
 
     @Column(name = "primary_style", nullable = false)
-    private int primaryStyle;
+    private String primaryStyle;
 
     @Column(name = "sub_style", nullable = false)
-    private int subStyle;
+    private String subStyle;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "team_pk")

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Team.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/domain/Team.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 @Getter
+@DynamicInsert
 public class Team {
 
     @Id
@@ -31,7 +33,7 @@ public class Team {
     private Match match; // match와 연관관계
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    private List<Participant> participants = new ArrayList<>(); // 참가자들 5명 씩 팀 1, 팀 2
+    private List<Participant> participants; // 참가자들 5명 씩 팀 1, 팀 2
 
     public void setMatch(Match match) {
         this.match = match;

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchDto.java
@@ -1,13 +1,8 @@
 package com.ggwp.searchservice.match.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.ggwp.searchservice.match.domain.Match;
-import com.ggwp.searchservice.match.domain.Participant;
-import com.ggwp.searchservice.match.domain.Team;
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Getter
@@ -22,94 +17,6 @@ public class MatchDto {
 
     @JsonProperty("metadata")
     private MetadataDto metadataDto;
-
-    public static MatchDto toDto(Match match) {
-
-        MetadataDto metadataDto = MetadataDto.builder()
-                .matchId(match.getMatchId())
-                .build();
-
-        List<TeamDto> teamDtoList = new ArrayList<>();
-        List<ParticipantDto> participantDtoList = new ArrayList<>();
-
-        List<Team> teamList = match.getTeams();
-        for (Team team : teamList) {
-            TeamDto teamDto = TeamDto.builder()
-                    .teamId(team.getTeamId())
-                    .win(team.isWin())
-                    .build();
-            teamDtoList.add(teamDto);
-
-            List<Participant> participantList = team.getParticipants();
-            for (Participant participant : participantList) {
-
-                PerkStyleDto primaryPerkStyleDto = PerkStyleDto.builder()
-                        .description("Primary Style Description")
-                        .style(participant.getPrimaryStyle())
-                        .build();
-
-                PerkStyleDto subPerkStyleDto = PerkStyleDto.builder()
-                        .description("Sub Style Description")
-                        .style(participant.getSubStyle())
-                        .build();
-
-                PerksDto perksDto = PerksDto.builder()
-                        .styles(Arrays.asList(primaryPerkStyleDto, subPerkStyleDto))
-                        .build();
-
-                ParticipantDto participantDto = ParticipantDto.builder()
-                        .participantId(participant.getParticipantId())
-                        .summonerId(participant.getSummonerId())
-                        .profileIcon(participant.getProfileIcon())
-                        .puuid(participant.getPuuid())
-                        .summmonerLevel(participant.getChampLevel())
-                        .summonerName(participant.getSummonerName())
-                        .kills(participant.getKills())
-                        .assists(participant.getAssists())
-                        .deaths(participant.getDeaths())
-                        .champExperience(participant.getChampExperience())
-                        .champLevel(participant.getChampLevel())
-                        .championId(participant.getChampionId())
-                        .championName(participant.getChampionName())
-                        .item0(participant.getItem0())
-                        .item1(participant.getItem1())
-                        .item2(participant.getItem2())
-                        .item3(participant.getItem3())
-                        .item4(participant.getItem4())
-                        .item5(participant.getItem5())
-                        .item6(participant.getItem6())
-                        .summoner1Id(participant.getSummoner1Id())
-                        .summoner2Id(participant.getSummoner2Id())
-                        .neutralMinionsKilled(participant.getNeutralMinionsKilled())
-                        .totalMinionsKilled(participant.getTotalMinionsKilled())
-                        .totalDamageDealtToChampions(participant.getTotalDamageDealtToChampions())
-                        .totalDamageTaken(participant.getTotalDamageTaken())
-                        .teamId(participant.getTeam().getTeamId())
-                        .perks(perksDto)
-                        .teamPosition(participant.getTeamPosition())
-                        .build();
-
-                participantDtoList.add(participantDto);
-            }
-        }
-
-        InfoDto infoDto = InfoDto.builder()
-                .gameCreation(match.getGameCreation())
-                .gameDuration(match.getGameDuration())
-                .gameStartTimestamp(match.getGameStartTimestamp())
-                .gameEndTimestamp(match.getGameEndTimestamp())
-                .platformId(match.getPlatformId())
-                .queueId(match.getQueueId())
-                .teams(teamDtoList)
-                .participants(participantDtoList)
-                .build();
-
-        return MatchDto.builder()
-                .info(infoDto)
-                .metadataDto(metadataDto)
-                .build();
-    }
-
 
     @Getter
     @Setter
@@ -141,7 +48,7 @@ public class MatchDto {
         private String platformId;
 
         @JsonProperty("queueId")
-        private Integer queueId;
+        private int queueId;
 
         @JsonProperty("teams")
         private List<TeamDto> teams;
@@ -241,42 +148,6 @@ public class MatchDto {
         private String teamPosition;
         /////////////////////////////////////////////////////////
 
-        public Participant toEntity(Team team) {
-            return Participant.builder()
-                    .participantId(this.participantId)
-                    .summonerId(this.summonerId)
-                    .profileIcon(this.profileIcon)
-                    .puuid(this.puuid)
-                    .summonerLevel(this.summmonerLevel)
-                    .summonerName(this.summonerName)
-                    .riotIdTagline(this.riotIdTagline)
-                    .kills(this.kills)
-                    .assists(this.assists)
-                    .deaths(this.deaths)
-                    .champExperience(this.champExperience)
-                    .champLevel(this.champLevel)
-                    .championId(this.championId)
-                    .championName(this.championName)
-                    .item0(this.item0)
-                    .item1(this.item1)
-                    .item2(this.item2)
-                    .item3(this.item3)
-                    .item4(this.item4)
-                    .item5(this.item5)
-                    .item6(this.item6)
-                    .summoner1Id(this.summoner1Id)
-                    .summoner2Id(this.summoner2Id)
-                    .neutralMinionsKilled(this.neutralMinionsKilled)
-                    .totalMinionsKilled(this.totalMinionsKilled)
-                    .totalDamageDealtToChampions(this.totalDamageDealtToChampions)
-                    .totalDamageTaken(this.totalDamageTaken)
-                    .primaryStyle(this.perks.getStyles().get(0).style)
-                    .subStyle(this.perks.getStyles().get(1).style)
-                    .teamPosition(this.teamPosition)
-                    .team(team)
-                    .build();
-        }
-
     }
 
     @Getter
@@ -315,11 +186,5 @@ public class MatchDto {
         @JsonProperty("win")
         private boolean win;
 
-        public Team toEntity() {
-            return Team.builder()
-                    .teamId(this.teamId)
-                    .win(this.win)
-                    .build();
-        }
     }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchSummonerDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/dto/MatchSummonerDto.java
@@ -10,7 +10,5 @@ import lombok.*;
 public class MatchSummonerDto {
     private String matchId;
     private String summonerId;
-    // 기타 필요한 필드 추가
-
 }
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/dto/RequestPageDto.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/dto/RequestPageDto.java
@@ -1,0 +1,14 @@
+package com.ggwp.searchservice.match.dto;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+//페이징 처리를 위한 DTO 클래스.
+public class RequestPageDto {
+    @Data
+    @Accessors(chain = true)
+    public static class Search {
+        private int page = 0;
+        private int size = 5;
+    }
+}

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchService.java
@@ -1,22 +1,19 @@
 package com.ggwp.searchservice.match.service;
 
-import com.ggwp.searchservice.common.dto.ResponseDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
-import com.ggwp.searchservice.match.domain.Match;
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.match.dto.MatchDto;
+import com.ggwp.searchservice.match.dto.RequestPageDto;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface MatchService {
-    List<String> getMatchIdsToFeign(TokenDto tokenDto);
 
-    MatchDto getMatchToFegin(String matchId);
+    void createMatches(FrontDto frontDto) throws InterruptedException;
 
-    Match matchToEntity(MatchDto matchDto);
+    List<MatchDto> getMatchList(FrontDto frontDto);
 
-    ResponseDto<String> createMatch(String matchId);
-
-    List<MatchDto> getMatchList(TokenDto tokenDto);
+    Page<MatchDto> pagedMatches(FrontDto frontDto, RequestPageDto.Search dto);
 
 
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchSummonerService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchSummonerService.java
@@ -8,10 +8,7 @@ import com.ggwp.searchservice.summoner.domain.Summoner;
 import java.util.List;
 
 public interface MatchSummonerService {
-
     List<MatchSummonerDto> getMatchSummonerBySummonerId(String summonerId);
-
-    MatchSummonerDto toDto(MatchSummoner matchSummoner);
 
     MatchSummoner createMatchSummoner(Match match, Summoner summoner);
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchSummonerServiceImpl.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/match/service/MatchSummonerServiceImpl.java
@@ -7,6 +7,7 @@ import com.ggwp.searchservice.match.dto.MatchSummonerDto;
 import com.ggwp.searchservice.summoner.domain.Summoner;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,25 +19,28 @@ public class MatchSummonerServiceImpl implements MatchSummonerService {
     private final MatchSummonerRepository matchSummonerRepository;
 
     // 소환사의 matchId들을 matchSummoner에서 가져오기
+    @Transactional(readOnly = true)
     public List<MatchSummonerDto> getMatchSummonerBySummonerId(String summonerId) {
         List<MatchSummoner> matchSummoners = matchSummonerRepository.findBySummonerId(summonerId);
 
         List<MatchSummonerDto> matchSummonerDtoList = new ArrayList<>();
 
         for (MatchSummoner matchSummoner : matchSummoners) {
-            MatchSummonerDto matchSummonerDto = toDto(matchSummoner);
+            MatchSummonerDto matchSummonerDto = matchSummonerToDto(matchSummoner);
             matchSummonerDtoList.add(matchSummonerDto);
         }
         return matchSummonerDtoList;
     }
 
-    public MatchSummonerDto toDto(MatchSummoner matchSummoner) {
+    private MatchSummonerDto matchSummonerToDto(MatchSummoner matchSummoner) {
         return MatchSummonerDto.builder()
                 .matchId(matchSummoner.getMatch().getMatchId())
                 .summonerId(matchSummoner.getSummoner().getId())
                 .build();
     }
 
+    @Transactional
+    @Override
     public MatchSummoner createMatchSummoner(Match match, Summoner summoner) {
         MatchSummoner matchSummoner = MatchSummoner.builder()
                 .match(match)

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/controller/SummonerController.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/controller/SummonerController.java
@@ -1,7 +1,7 @@
 package com.ggwp.searchservice.summoner.controller;
 
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.common.dto.ResponseDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
 import com.ggwp.searchservice.summoner.dto.ResponseSummonerDto;
 import com.ggwp.searchservice.summoner.service.SummonerService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +23,7 @@ public class SummonerController {
 
     @PostMapping("/get") // 롤 puuid로 Summoner 가져오기 No-API
     @Operation(summary = "Summoner 조회", description = "DB로 조회")
-    public ResponseDto<ResponseSummonerDto> getSummoner(@Valid @RequestBody TokenDto tokenDto) {
-        return summonerService.getSummoner(tokenDto);
+    public ResponseDto<ResponseSummonerDto> getSummoner(@Valid @RequestBody FrontDto frontDto) {
+        return ResponseDto.success(summonerService.getSummoner(frontDto));
     }
 }

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerService.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerService.java
@@ -1,14 +1,13 @@
 package com.ggwp.searchservice.summoner.service;
 
 import com.ggwp.searchservice.account.domain.Account;
-import com.ggwp.searchservice.common.dto.ResponseDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.summoner.domain.Summoner;
 import com.ggwp.searchservice.summoner.dto.CreateSummonerDto;
 import com.ggwp.searchservice.summoner.dto.ResponseSummonerDto;
 
 public interface SummonerService {
-    ResponseDto<ResponseSummonerDto> getSummoner(TokenDto tokenDto); // DB 조회하여 소환사 정보 가져오기
+    ResponseSummonerDto getSummoner(FrontDto frontDto); // DB 조회하여 소환사 정보 가져오기
 
     Summoner findSummoner(Account account); // Optional<Summoner> 찾기
 

--- a/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerServiceImpl.java
+++ b/Search-service/src/main/java/com/ggwp/searchservice/summoner/service/SummonerServiceImpl.java
@@ -2,8 +2,7 @@ package com.ggwp.searchservice.summoner.service;
 
 import com.ggwp.searchservice.account.domain.Account;
 import com.ggwp.searchservice.account.service.AccountService;
-import com.ggwp.searchservice.common.dto.ResponseDto;
-import com.ggwp.searchservice.common.dto.TokenDto;
+import com.ggwp.searchservice.common.dto.FrontDto;
 import com.ggwp.searchservice.common.exception.CustomException;
 import com.ggwp.searchservice.common.exception.ErrorCode;
 import com.ggwp.searchservice.summoner.domain.Summoner;
@@ -12,8 +11,10 @@ import com.ggwp.searchservice.summoner.dto.ResponseSummonerDto;
 import com.ggwp.searchservice.summoner.repository.SummonerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class SummonerServiceImpl implements SummonerService {
 
@@ -27,12 +28,15 @@ public class SummonerServiceImpl implements SummonerService {
     }
 
     @Override  //DB에 저장한 소환사 정보 가져오기 No-API
-    public ResponseDto<ResponseSummonerDto> getSummoner(TokenDto tokenDto) {
-        Account account = accountService.findAccount(tokenDto);
+    @Transactional(readOnly = true)
+    public ResponseSummonerDto getSummoner(FrontDto frontDto) {
+        Account account = accountService.findAccount(frontDto);
         Summoner summoner = findSummoner(account);
-        return ResponseDto.success(summoner.toDto(summoner));
+        return summoner.toDto(summoner);
     }
 
+    @Override
+    @Transactional(readOnly = true)
     public boolean existSummoner(CreateSummonerDto createSummonerDto) {
         return summonerRepository.existsByPuuid(createSummonerDto.getPuuid());
     }


### PR DESCRIPTION
매치 처리 과정은...
feign	1	matchIds
feign	2	match (match안에는 옛날 소환사 이름이 담겨있다.)
feign	10	match의 리그 저장
feign	10	account의 저장 (새로 바뀐 닉네임으로 바꾸기 위함)
--> 현재 라이엇 api 이슈 발생 (태그 이슈 수정하는 건지 모르겠음) -> 확인 불가능 -> 일단 리팩토링 완료
https://github.com/RiotGames/developer-relations/issues/860

총 23
- 리그와 계정이 최신이면 feign을 호출하지않고 넘어가게끔 처리를 해야할 것 같다. ( matchIds는 feign 무조건 써야함) 1번 호출
- matchIds가 최신이면 저장할 필요가 없다.. - 처리
- 없는것만 저장

1. global Exception -> 처리
2. Enum 처리 -> 일단 처리
3. 페이징 처리(QueryDsl 적용) ->  처리
4. 5판 이후에 게임은 어떻게 할 것인가 처리 (프론트에서 페이징 번호 주기)
5. 이전 참가자 이름만 담기는 것 같다.. -> 업데이트된 참가자 이름이 담겨야하는데?
- 처리 -> 단 participant에 이름은 바뀌지 않음 (Summoner와 Account는 변경했음)
6. 트랜잭션 처리
- 처리
- 낙관적 락
- Dynamic Insert,Update 적용